### PR TITLE
I have set fog upload to be private

### DIFF
--- a/lib/s3_helpers.rb
+++ b/lib/s3_helpers.rb
@@ -114,8 +114,7 @@ if defined?(Fog)
   def HerokuMongoBackup::s3_upload(directory, filename)
     file = directory.files.create(
       :key    => "backups/#{filename}",
-      :body   => open(filename),
-      :public => true
+      :body   => open(filename)
     )    
   end
 


### PR DESCRIPTION
S3 upload via fog gem should be private. Access is not specified right now for S3 or aws/s3 implementation in storage_helper, so fog should probably be the same?

-thanks
